### PR TITLE
docs: remove duplicated text

### DIFF
--- a/apps/docs/concepts/injection.md
+++ b/apps/docs/concepts/injection.md
@@ -94,7 +94,6 @@ So instead of:
 }
 ```
 Please use:
-So instead of:
 ```ts
 {
   provide: LOGGER,


### PR DESCRIPTION
Very minor issue in the docs.

Remove duplicated "So instead of:"

<img width="719" height="651" alt="Screenshot 2025-09-10 at 2 01 15 PM" src="https://github.com/user-attachments/assets/55a77ffd-6842-47ba-aac9-9829b923f828" />
