### PR TITLE
Add has check on parent container if child does not have bound token

### DIFF
--- a/packages/core/src/container.test.ts
+++ b/packages/core/src/container.test.ts
@@ -69,12 +69,15 @@ describe("Container API", () => {
 
   it("has", async () => {
     const container = new Container();
+    const childContainer = container.createChild();
     const token = new InjectionToken<MyService>("some-token");
 
     expect(container.has(token)).toBe(false);
+    expect(childContainer.has(token)).toBe(false);
 
     container.bind({ provide: token, useClass: MyService });
     expect(container.has(token)).toBe(true);
+    expect(childContainer.has(token)).toBe(true);
 
     // has shall not create a provider, even if it is async
     const asyncToken = new InjectionToken<MyService>("some-async-token");

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -332,7 +332,11 @@ export class Container {
    * Returns whether the container has one or more providers for this token.
    */
   public has<T>(token: Token<T>): boolean {
-    return this.providers.has(token);
+    let found = this.providers.has(token);
+    if (!found && this.parent) {
+      return this.parent.has(token);
+    }
+    return found;
   }
 
   private autoBindIfNeeded<T>(token: Token<T>) {


### PR DESCRIPTION
When calling `resolve(token)` the container will call the parent `resolve()` if the child container doesn't have a binding, however when checking for a component with `has(token)` a child component returns `false` even if a binding could be resolved on a parent container.