### PR TITLE
fix(container): traverse parent container in getAsync()

### DIFF
--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -311,6 +311,9 @@ export class Container {
       const optional = options?.optional ?? false;
 
       if (!this.providers.has(token)) {
+        if (this.parent) {
+          return this.parent.getAsync(token, { ...options, lazy: false });
+        }
         if (optional) {
           return undefined;
         }

--- a/packages/core/src/providers.test.ts
+++ b/packages/core/src/providers.test.ts
@@ -467,6 +467,55 @@ describe("Providers", () => {
       expect(parent.get("tokenA", { multi: true })).toEqual(["a1", "a2"]);
       expect(child.get("tokenA", { multi: true })).toEqual(["a3", "a4"]);
     });
+
+    it("should resolve async providers from parent via getAsync()", async () => {
+      const parent = new Container();
+      const child = parent.createChild();
+      const grandChild = child.createChild();
+
+      parent.bind({ provide: "tokenA", async: true, useFactory: async () => ["a"] });
+      child.bind({ provide: "tokenB", async: true, useFactory: async () => ["b"] });
+      grandChild.bind({ provide: "tokenC", async: true, useFactory: async () => ["c"] });
+
+      expect(await grandChild.getAsync("tokenA")).toEqual(["a"]);
+      expect(await grandChild.getAsync("tokenB")).toEqual(["b"]);
+      expect(await grandChild.getAsync("tokenC")).toEqual(["c"]);
+
+      expect(await child.getAsync("tokenA")).toEqual(["a"]);
+      expect(await child.getAsync("tokenB")).toEqual(["b"]);
+      await expect(child.getAsync("tokenC")).rejects.toThrowError("No provider(s) found for tokenC");
+
+      expect(await parent.getAsync("tokenA")).toEqual(["a"]);
+      await expect(parent.getAsync("tokenB")).rejects.toThrowError("No provider(s) found for tokenB");
+    });
+
+    it("should reuse async singletons from their parent via getAsync()", async () => {
+      const parent = new Container();
+      const child = parent.createChild();
+      const grandChild = child.createChild();
+
+      parent.bind({ provide: "tokenA", async: true, useFactory: async () => ["a"] });
+      child.bind({ provide: "tokenB", async: true, useFactory: async () => ["b"] });
+
+      const a1 = await parent.getAsync("tokenA");
+      const a2 = await grandChild.getAsync("tokenA");
+      const a3 = await child.getAsync("tokenA");
+
+      const b1 = await child.getAsync("tokenB");
+      const b2 = await grandChild.getAsync("tokenB");
+
+      expect(a1).toBe(a2);
+      expect(a2).toBe(a3);
+
+      expect(b1).toBe(b2);
+    });
+
+    it("should return undefined for optional async tokens not found in parent", async () => {
+      const parent = new Container();
+      const child = parent.createChild();
+
+      expect(await child.getAsync("missing", { optional: true })).toBeUndefined();
+    });
   });
 
   describe("Lazy injection", () => {


### PR DESCRIPTION
## Summary

`getAsync()` does not delegate to the parent container when a token is missing locally. `get()` already does. A child container created via `createChild()` throws `No provider(s) found` for tokens bound in a parent when resolved through `getAsync()`.

## Fix

Mirror the parent delegation from `get()` into `getAsync()`:

```typescript
if (!this.providers.has(token)) {
  if (this.parent) {
    return this.parent.getAsync(token, { ...options, lazy: false });
  }
  // ...
}
```

## Tests

Three tests added under "Child containers" in `providers.test.ts`:

- Resolves async providers from ancestor containers via `getAsync()`
- Reuses async singletons from parent (identity check)
- Returns `undefined` for optional tokens not found in any ancestor