### PR TITLE
fix: phantom CircularDependencyError from underConstruction stack corruption under concurrent async constructions

### DIFF
--- a/packages/core/src/container.test.ts
+++ b/packages/core/src/container.test.ts
@@ -129,6 +129,73 @@ describe("Container API", () => {
     });
   });
 
+  describe("concurrent async constructions", () => {
+    // https://github.com/needle-di/needle-di/issues/102
+    it("should not report a phantom circular dependency when a failed construction is retried while another is in flight", async () => {
+      const tokenA = new InjectionToken<string>("A");
+      const tokenB = new InjectionToken<string>("B");
+
+      let aAttempts = 0;
+      let releaseB!: () => void;
+      const bGate = new Promise<void>((resolve) => (releaseB = resolve));
+
+      const container = new Container();
+      container.bind({
+        provide: tokenA,
+        async: true,
+        useFactory: async () => {
+          aAttempts += 1;
+          if (aAttempts === 1) {
+            await Promise.resolve(); // yield so B's construction can start before A fails
+            throw new Error("transient failure");
+          }
+          return "a-value";
+        },
+      });
+      container.bind({
+        provide: tokenB,
+        async: true,
+        useFactory: async () => {
+          await bGate; // keep B's construction in flight
+          return "b-value";
+        },
+      });
+
+      // A starts, then B starts; A then fails while B is still under construction.
+      const aFirst = container.getAsync(tokenA).catch((error: Error) => error);
+      const bPending = container.getAsync(tokenB);
+      const aFirstResult = await aFirst;
+      expect(aFirstResult).toBeInstanceOf(Error);
+      expect((aFirstResult as Error).message).toBe("transient failure");
+
+      // Retrying A while B is still in flight must not throw a circular dependency error:
+      // A has no dependencies at all.
+      await expect(container.getAsync(tokenA)).resolves.toBe("a-value");
+
+      releaseB();
+      await expect(bPending).resolves.toBe("b-value");
+    });
+
+    it("should still detect real circular dependencies in async constructions", async () => {
+      const tokenA = new InjectionToken<string>("A");
+      const tokenB = new InjectionToken<string>("B");
+
+      const container = new Container();
+      container.bind({
+        provide: tokenA,
+        async: true,
+        useFactory: async () => `a(${await injectAsync(tokenB)})`,
+      });
+      container.bind({
+        provide: tokenB,
+        async: true,
+        useFactory: async () => `b(${await injectAsync(tokenA)})`,
+      });
+
+      await expect(container.getAsync(tokenA)).rejects.toThrowError(/circular dependency/i);
+    });
+  });
+
   it("should unbind a single service", () => {
     const container = new Container();
 

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -31,14 +31,14 @@ export class Factory {
   }
 
   async constructAsync<T>(provider: Provider<T>): Promise<T[]> {
+    if (this.underConstruction.includes(provider)) {
+      const dependencyGraph = [...this.underConstruction, provider].map(getToken).map(toString);
+      throw new CircularDependencyError(dependencyGraph);
+    }
+
+    this.underConstruction.push(provider);
+
     try {
-      if (this.underConstruction.includes(provider)) {
-        const dependencyGraph = [...this.underConstruction, provider].map(getToken).map(toString);
-        throw new CircularDependencyError(dependencyGraph);
-      }
-
-      this.underConstruction.push(provider);
-
       if (Guards.isAsyncProvider(provider)) {
         return [await provider.useFactory(this.container)];
       }
@@ -67,7 +67,13 @@ export class Factory {
       // all other types of providers are constructed synchronously anyway.
       return this.doConstruct(provider);
     } finally {
-      this.underConstruction.pop();
+      // Concurrent async constructions can settle in any order, so `pop()` might remove
+      // another in-flight construction's entry and leave our own entry stranded, causing
+      // phantom `CircularDependencyError`s on retries. Remove our own entry by identity instead.
+      const index = this.underConstruction.lastIndexOf(provider);
+      if (index !== -1) {
+        this.underConstruction.splice(index, 1);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #102.

## Problem

`Factory.underConstruction` is one shared array per container, and `constructAsync` unwound it with an unconditional `finally { this.underConstruction.pop() }`. `pop()` removes the most recently pushed entry, so it is only correct when concurrent async constructions settle in LIFO order. When two constructions of different tokens overlap and the first-started one settles first, it popped the other construction's entry and left its own entry stranded on the stack. A failed construction retried while another construction was still in flight then hit the stale entry and threw a phantom `CircularDependencyError` for a token with no dependencies at all (see the minimal repro in #102).

## Fix

- Remove the entry **by identity** (`lastIndexOf` + `splice`) instead of by position, so a construction only ever removes its own entry.
- Move the cycle check and `push` outside the `try`, so the `finally` never removes an entry that this construction did not push (previously, detecting a real cycle popped the *outer* construction's entry).

The sync `construct` path is unchanged: synchronous constructions cannot interleave, so pushes/pops there are strictly LIFO.

As noted in the issue, a deeper follow-up could make cycle detection per-chain (a single shared array can still conflate concurrent, unrelated chains constructing the same provider), but this change eliminates the corruption/phantom-error class with minimal surface.

## Tests

- Regression test reproducing the interleaving from the issue (fails on `main` with the phantom circular-dependency error, passes with the fix).
- A test that real async circular dependencies are still detected.

Full suite passes; `tsc`, `eslint`, and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)