### PR TITLE
fix: injectAsync resolving from the wrong container via leaked injection context

### DIFF
--- a/packages/core/src/container.test.ts
+++ b/packages/core/src/container.test.ts
@@ -127,6 +127,85 @@ describe("Container API", () => {
       expect(() => container3.get("e")).toThrowError("No provider(s) found for b");
       expect(() => container3.get("b")).toThrowError("No provider(s) found for b");
     });
+
+    // https://github.com/needle-di/needle-di/issues/103
+    it("should not leak the injection context of a suspended async construction", async () => {
+      const tokenA = new InjectionToken<string>("A");
+      const tokenB = new InjectionToken<string>("B");
+      const tokenT = new InjectionToken<{ a: string; b: string }>("T");
+      const tokenT2 = new InjectionToken<{ a: string; b: string }>("T2");
+
+      let releaseA!: () => void;
+      const aGate = new Promise<void>((resolve) => (releaseA = resolve));
+
+      const parent = new Container();
+      parent.bind({
+        provide: tokenA,
+        async: true,
+        useFactory: async () => {
+          await aGate; // suspend: the parent's injection context must not stay active meanwhile
+          return "a-from-parent";
+        },
+      });
+      parent.bind({ provide: tokenB, useValue: "b-from-parent" });
+
+      const child = parent.createChild();
+      child.bind({ provide: tokenB, useValue: "b-from-child" });
+      child.bind({
+        provide: tokenT, // bound on the child: its injections should resolve child-first
+        async: true,
+        useFactory: async () => {
+          const aPromise = injectAsync(tokenA); // descends into the parent and suspends there
+          const bPromise = injectAsync(tokenB); // must not read a leaked parent context
+          return { a: await aPromise, b: await bPromise };
+        },
+      });
+      child.bind({
+        provide: tokenT2, // control case: identical, but B injected before A
+        async: true,
+        useFactory: async () => {
+          const bPromise = injectAsync(tokenB);
+          const aPromise = injectAsync(tokenA);
+          return { a: await aPromise, b: await bPromise };
+        },
+      });
+
+      const tPending = child.getAsync(tokenT);
+      releaseA();
+
+      expect(await tPending).toEqual({ a: "a-from-parent", b: "b-from-child" });
+      expect(await child.getAsync(tokenT2)).toEqual({ a: "a-from-parent", b: "b-from-child" });
+    });
+
+    // https://github.com/needle-di/needle-di/issues/103
+    it("should not allow inject() outside an injection context while an async construction is suspended", async () => {
+      const token = new InjectionToken<string>("suspended");
+
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => (release = resolve));
+
+      const container = new Container();
+      container.bind({ provide: "value", useValue: "some-value" });
+      container.bind({
+        provide: token,
+        async: true,
+        useFactory: async () => {
+          await gate;
+          return "done";
+        },
+      });
+
+      const pending = container.getAsync(token);
+
+      // While the construction above is suspended, unrelated code must still be
+      // outside any injection context.
+      expect(() => inject("value")).toThrowError(
+        "You can only invoke inject() or injectAsync() within an injection context",
+      );
+
+      release();
+      await expect(pending).resolves.toBe("done");
+    });
   });
 
   it("should unbind a single service", () => {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,5 +1,6 @@
 import { Container } from "./container.ts";
 import type { Token } from "./tokens.ts";
+import { promiseTry } from "./utils.ts";
 
 /**
  * Injects a service within the current injection context, using the token provided.
@@ -107,13 +108,17 @@ class InjectionContext implements Context {
     }
   }
 
-  async runAsync<T>(block: (container: Container) => Promise<T> | T): Promise<T> {
+  runAsync<T>(block: (container: Container) => Promise<T> | T): Promise<T> {
     const originalContext = _currentContext;
     try {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       _currentContext = this;
-      return await block(this.container);
+      return promiseTry(() => block(this.container));
     } finally {
+      // The context must be restored synchronously, as soon as the block's synchronous
+      // prefix has returned its promise. Holding it across the `await` (i.e. until the
+      // promise settles) leaks this context to unrelated code that runs while the block
+      // is suspended, making `inject()`/`injectAsync()` resolve from the wrong container.
       _currentContext = originalContext;
     }
   }

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -3,6 +3,7 @@ import { getToken, type Token, toString } from "./tokens.ts";
 import * as Guards from "./providers.ts";
 import { assertNever, retryOn } from "./utils.ts";
 import { Container } from "./container.ts";
+import { injectionContext } from "./context.ts";
 
 /**
  * @internal
@@ -53,7 +54,10 @@ export class Factory {
 
         return retryOn(
           AsyncProvidersInSyncInjectionContextError,
-          async () => create(),
+          // retries run in a later tick, when the original injection context is no longer
+          // active, so each attempt must explicitly (re-)enter the injection context for
+          // the field initializers' inject() calls to work.
+          async () => injectionContext(this.container).run(() => create()),
           async (error) => {
             await this.container.getAsync(error.token, { multi: true, optional: true });
           },


### PR DESCRIPTION
Fixes #103.

## Problem

`InjectionContext.runAsync` set the module-global `_currentContext` synchronously but restored it only in a `finally` that runs when the awaited block **settles**. When a factory's synchronous prefix issued an `injectAsync(A)` whose construction suspended, the suspended construction's context was left in the global, so the very next `injectAsync(B)` on the same synchronous prefix resolved from the **wrong container**. With parent/child containers this silently bypassed child overrides, making resolution order-dependent: two factories that differ only in the order of their `injectAsync` calls received different values for the same token (see the minimal repro in #103). The leak also put unrelated code (running while some construction was suspended) inside a phantom injection context.

## Fix

This is the portable option from the issue (no `AsyncLocalStorage` dependency, so browsers keep working):

- `runAsync` now restores the global **synchronously** after the block's synchronous prefix has returned its promise — the context never survives across an `await`. Sync throws from the block still become rejections (via `promiseTry`), as before.
- The class/constructor-provider retry path in `Factory.constructAsync` — the one consumer that relied on the leak, because `retryOn` re-runs `new provider.useClass()` in a later tick after awaiting async deps — now explicitly re-enters the injection context around each `create()` attempt.

This keeps the documented "injection only during a synchronous prefix" contract airtight everywhere.

## Tests

- Regression test for the parent/child override bypass from the issue (fails on `main`: `T` gets `b-from-parent`; passes with the fix).
- Regression test that `inject()` outside any injection context throws even while an unrelated async construction is suspended (fails on `main`).
- The existing suite covers the class-provider-with-async-deps retry path that constrained this fix — all tests pass.

`tsc`, `eslint`, and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)