### PR TITLE
feat(inject): expose injection context and more smartly instantiate the injection context

### DIFF
--- a/apps/docs/concepts/injection.md
+++ b/apps/docs/concepts/injection.md
@@ -72,7 +72,8 @@ Note that the `inject()` and `injectAsync()` functions are only available in the
 - During construction of a class being instantiated by the DI container;
 - In the initializer for fields of such classes;
 - In a synchronous factory function specified for `useFactory` of a provider;
-- In the `factory` function specified for an `InjectionToken`.
+- In the `factory` function specified for an `InjectionToken`;
+- Under `InjectionContext.run()` before any asynchronous execution
 
 If you try to use this function outside this context, it will throw
 an error. This is because Needle DI needs a reference to a DI container when
@@ -106,27 +107,47 @@ Please use:
 ```
 :::
 
-## Manual Injection
+## Executing under injection context
 
 Situations where classes aren't used but rather functions can still benefit from
-dependency injection.
+dependency injection. You can still use `inject()` and `injectAsync()` by obtaining
+the `InjectionContext` of a container and running `.run()`. It also allows you to return
+any value
 
-In these cases, manually passing the singleton container instance as an argument
-to the function and using the `.get()` function within provides the same practical
-functionality as using classes with decorators, just with reduced ergonomics.
-
-```ts
-import type { Container } from "@needle-di/core";
+```ts twoslash
+import { InjectionContext, inject, Container } from "@needle-di/core";
 
 import { FooService } from "./foo.service";
-import { BarService } from "./bar.service";
 
-const createMyService = (container: Container) => {
-  fooService = container.get(FooService);
-  barService = container.get(BarService);
+const container = new Container()
 
-  // ...
+const executeServices = () => {
+  const fooService = inject(FooService);
+  
+  return fooService.someMethod()
 }
+
+const injection = container.get(InjectionContext)
+const execution = injection.run(() => executeServices())
+```
+
+In cases where you have to run an async function, `inject()` has to be ran before
+any asynchronous code is executed.
+
+```ts twoslash
+import { InjectionContext, inject, Container } from "@needle-di/core";
+
+import { FooService } from "./foo.service";
+
+const container = new Container()
+
+const promise = new Promise(() => {})
+
+container.get(InjectionContext).run(async () => {
+  const fooService = inject(FooService);
+  await promise;
+  // after this point there is no access to the injection context
+})
 ```
 
 [parameter decorators]: https://github.com/tc39/proposal-class-method-parameter-decorators

--- a/apps/docs/foo.service.ts
+++ b/apps/docs/foo.service.ts
@@ -3,6 +3,5 @@ import { injectable } from "@needle-di/core";
 @injectable()
 export class FooService {
   // ...
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  someMethod(): void {}
+  someMethod() {return "Return of FooService.someMethod()" as const}
 }

--- a/packages/core/src/container.test.ts
+++ b/packages/core/src/container.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { bootstrap, bootstrapAsync, Container } from "./container.ts";
 import { injectable } from "./decorators.ts";
 import { InjectionToken } from "./tokens.ts";
-import { inject, injectAsync } from "./context.ts";
+import { inject, injectAsync, InjectionContext, NeedsInjectionContextError } from "./context.ts";
 
 const myServiceConstructorSpy = vi.fn();
 
@@ -199,12 +199,55 @@ describe("Container API", () => {
 
       // While the construction above is suspended, unrelated code must still be
       // outside any injection context.
-      expect(() => inject("value")).toThrowError(
-        "You can only invoke inject() or injectAsync() within an injection context",
-      );
+      expect(() => inject("value")).toThrowError(NeedsInjectionContextError);
 
       release();
       await expect(pending).resolves.toBe("done");
+    });
+
+    it("should expose an injection context to be used anywhere and obtain services using inject()", async () => {
+      const token = new InjectionToken<string>("suspended");
+      const comparedValue = "woooo";
+
+      const container = new Container();
+      container.bind({
+        provide: token,
+        useValue: comparedValue,
+      });
+
+      const funcTest = () => inject(token);
+
+      const execution = container.get(InjectionContext).run(() => funcTest());
+
+      expect(execution).toBe(comparedValue);
+    });
+
+    it("should not allow execution of asynchronous functions on InjectionContext.run", async () => {
+      const token = new InjectionToken<string>("suspended");
+      const comparedValue = "woooo";
+
+      let release!: () => void;
+      const outsideOfInjection = new Promise<void>((resolve) => (release = resolve));
+      // let reachedAwait!: () => void;
+      // const insideInjection = new Promise<void>((resolve) => (reachedAwait = resolve));
+
+      const container = new Container();
+      container.bind({
+        provide: token,
+        useValue: comparedValue,
+      });
+
+      const funcTest = async () => {
+        expect(inject(token)).toBe(comparedValue);
+        await outsideOfInjection;
+        expect(() => inject(token)).toThrow(NeedsInjectionContextError);
+      };
+
+      const execution = container.get(InjectionContext).run(() => funcTest());
+
+      release();
+
+      await execution;
     });
   });
 

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -4,7 +4,7 @@ import type { Provider } from "./providers.ts";
 import { getInjectableTargets, isInjectable } from "./decorators.ts";
 import { assertPresent, assertSingle, getParentClasses, promiseTry, windowedSlice } from "./utils.ts";
 import { Factory } from "./factory.ts";
-import { injectionContext } from "./context.ts";
+import { InjectionContext } from "./context.ts";
 
 /**
  * A dependency injection (DI) container will keep track of all bindings
@@ -16,14 +16,22 @@ export class Container {
 
   private readonly parent?: Container;
   private readonly factory: Factory;
+  private readonly injector: InjectionContext;
 
   constructor(parent?: Container) {
     this.parent = parent;
     this.factory = new Factory(this);
-    this.bind({
-      provide: Container,
-      useValue: this,
-    });
+    this.injector = new InjectionContext(this);
+    this.bindAll(
+      {
+        provide: Container,
+        useValue: this,
+      },
+      {
+        provide: InjectionContext,
+        useValue: this.injector,
+      },
+    );
   }
 
   /**
@@ -238,7 +246,7 @@ export class Container {
     const providers = assertPresent(this.providers.get(token));
 
     if (!this.singletons.has(token)) {
-      injectionContext(this).run(() => {
+      this.injector.run(() => {
         const values = providers.flatMap((provider) => this.factory.construct(provider, token));
         this.singletons.set(token, values);
       });
@@ -323,7 +331,7 @@ export class Container {
       const providers = assertPresent(this.providers.get(token));
 
       if (!this.singletons.has(token)) {
-        await injectionContext(this).runAsync(async () => {
+        await this.injector.run(async () => {
           const values = await Promise.all(providers.map((it) => this.factory.constructAsync(it)));
 
           this.singletons.set(token, values.flat());

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,7 +18,7 @@ export function inject<T>(
   options?: { optional?: boolean; multi?: boolean; lazy?: boolean },
 ): T | T[] | undefined | (() => T | T[] | undefined) {
   try {
-    return _currentContext.run((container) => container.get(token, options));
+    return _currentContext.boundedContainer.get(token, options);
   } catch (error) {
     if (error instanceof NeedsInjectionContextError && options?.optional === true) {
       return undefined;
@@ -52,9 +52,9 @@ export function injectAsync<T>(
 ): Promise<T | T[] | undefined> | (() => Promise<T | T[] | undefined>) {
   try {
     if (options?.lazy) {
-      return _currentContext.run((container) => container.getAsync(token, { ...options, lazy: true }));
+      return _currentContext.boundedContainer.getAsync(token, { ...options, lazy: true });
     }
-    return _currentContext.runAsync((container) => container.getAsync(token, { ...options, lazy: false }));
+    return promiseTry(() => _currentContext.boundedContainer.getAsync(token, { ...options, lazy: false }));
   } catch (error) {
     if (error instanceof NeedsInjectionContextError && options?.optional === true) {
       return Promise.resolve(undefined);
@@ -70,8 +70,9 @@ export function injectAsync<T>(
  * @internal
  */
 interface Context {
+  readonly boundedContainer: Container;
   run<T>(block: (container: Container) => T): T;
-  runAsync<T>(block: (container: Container) => Promise<T>): Promise<T>;
+  // runAsync<T>(block: (container: Container) => Promise<T>): Promise<T>;
 }
 
 /**
@@ -80,40 +81,27 @@ interface Context {
  * @internal
  */
 class GlobalContext implements Context {
-  run<T>(): T {
+  get boundedContainer(): Container {
     throw new NeedsInjectionContextError();
   }
-
-  runAsync<T>(): Promise<T> {
+  run<T>(): T {
     throw new NeedsInjectionContextError();
   }
 }
 
 /**
- * An injection context allows to perform dependency injection with `inject()` and `injectAsync()`.
- *
- * @internal
+ * Runs a function inside an injection context.
+ * Useful if you have an utility that relies on `inject()` and `injectAsync()`.
  */
-class InjectionContext implements Context {
-  constructor(private readonly container: Container) {}
+export class InjectionContext implements Context {
+  constructor(public readonly boundedContainer: Container) {}
 
   run<T>(block: (container: Container) => T): T {
     const originalContext = _currentContext;
     try {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       _currentContext = this;
-      return block(this.container);
-    } finally {
-      _currentContext = originalContext;
-    }
-  }
-
-  runAsync<T>(block: (container: Container) => Promise<T> | T): Promise<T> {
-    const originalContext = _currentContext;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      _currentContext = this;
-      return promiseTry(() => block(this.container));
+      return block(this.boundedContainer);
     } finally {
       // The context must be restored synchronously, as soon as the block's synchronous
       // prefix has returned its promise. Holding it across the `await` (i.e. until the
@@ -127,20 +115,11 @@ class InjectionContext implements Context {
 let _currentContext: GlobalContext | InjectionContext = new GlobalContext();
 
 /**
- * Creates a new injection context.
- *
- * @internal
- */
-export function injectionContext(container: Container): Context {
-  return new InjectionContext(container);
-}
-
-/**
  * An error that occurs when `inject()` or `injectAsync()` is used outside an injection context.
  *
  * @internal
  */
-class NeedsInjectionContextError extends Error {
+export class NeedsInjectionContextError extends Error {
   constructor() {
     super(`You can only invoke inject() or injectAsync() within an injection context`);
   }

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -3,7 +3,7 @@ import { getToken, type Token, toString } from "./tokens.ts";
 import * as Guards from "./providers.ts";
 import { assertNever, retryOn } from "./utils.ts";
 import { Container } from "./container.ts";
-import { injectionContext } from "./context.ts";
+import { InjectionContext } from "./context.ts";
 
 /**
  * @internal
@@ -57,7 +57,7 @@ export class Factory {
           // retries run in a later tick, when the original injection context is no longer
           // active, so each attempt must explicitly (re-)enter the injection context for
           // the field initializers' inject() calls to work.
-          async () => injectionContext(this.container).run(() => create()),
+          async () => this.container.get(InjectionContext).run(() => create()),
           async (error) => {
             await this.container.getAsync(error.token, { multi: true, optional: true });
           },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { Container, bootstrap, bootstrapAsync } from "./container.ts";
-export { inject, injectAsync } from "./context.ts";
+export { inject, injectAsync, InjectionContext } from "./context.ts";
 export { injectable } from "./decorators.ts";
 export type {
   Provider,


### PR DESCRIPTION
Exposes the injection context to anyone use externally. Allows for the execution of inject() inside functions by manually instantiating a context

```ts
import { InjectionContext, inject, Container } from "@needle-di/core";

import { FooService } from "./foo.service";

const container = new Container()

const executeServices = () => {
  const fooService = inject(FooService);
  
  return fooService.someMethod()
}

const injection = container.get(InjectionContext)
const execution = injection.run(() => executeServices())
```

It also records the class inside the container to avoid multiple instantiations of InjectionContext, improving resource usage